### PR TITLE
Improve SEC retry handling and treat any SEC/Edgar rate limits as infra errors

### DIFF
--- a/finance_agent/exceptions.py
+++ b/finance_agent/exceptions.py
@@ -5,6 +5,7 @@ from typing import Any
 import aiohttp
 import backoff
 import httpx
+from tavily import UsageLimitExceededError
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,8 @@ def _get_status_code(exception: Exception) -> int | None:
         return exception.status
     if isinstance(exception, httpx.HTTPStatusError):
         return exception.response.status_code
+    if isinstance(exception, UsageLimitExceededError):
+        return 429
     return None
 
 

--- a/finance_agent/exceptions.py
+++ b/finance_agent/exceptions.py
@@ -39,40 +39,43 @@ def retry_with_policy(policy: RetryPolicy) -> Callable:
         @retry_with_policy({429: 20, 503: 3})
         async def fetch(url): ...
     """
-    attempt_counts: dict[int, int] = {}
-
-    def should_retry(exception: Exception) -> bool:
-        code = _get_status_code(exception)
-        if code is None:
-            for c in policy:
-                if str(c) in str(exception):
-                    code = c
-                    break
-        if code is None or code not in policy:
-            return False
-
-        attempt_counts[code] = attempt_counts.get(code, 0) + 1
-        if attempt_counts[code] > policy[code]:
-            return False
-
-        logger.error(f"{code} error: {exception}")
-        return True
-
     overall_max = max(policy.values()) if policy else 1
 
     def decorator(func: Callable) -> Callable:
-        @backoff.on_exception(
-            backoff.expo,
-            Exception,
-            max_tries=overall_max,
-            max_value=120,
-            base=2,
-            factor=3,
-            jitter=backoff.full_jitter,
-            giveup=lambda e: not should_retry(e),
-        )
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            return await func(*args, **kwargs)
+            attempt_counts: dict[int, int] = {}
+
+            def should_retry(exception: Exception) -> bool:
+                code = _get_status_code(exception)
+                if code is None:
+                    for c in policy:
+                        if str(c) in str(exception):
+                            code = c
+                            break
+                if code is None or code not in policy:
+                    return False
+
+                attempt_counts[code] = attempt_counts.get(code, 0) + 1
+                if attempt_counts[code] > policy[code]:
+                    return False
+
+                logger.error(f"{code} error: {exception}")
+                return True
+
+            @backoff.on_exception(
+                backoff.expo,
+                Exception,
+                max_tries=overall_max,
+                max_value=120,
+                base=2,
+                factor=3,
+                jitter=backoff.full_jitter,
+                giveup=lambda e: not should_retry(e),
+            )
+            async def _retrying(*a: Any, **kw: Any) -> Any:
+                return await func(*a, **kw)
+
+            return await _retrying(*args, **kwargs)
 
         return wrapper
 

--- a/finance_agent/exceptions.py
+++ b/finance_agent/exceptions.py
@@ -9,6 +9,12 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+class RetryExhaustedError(Exception):
+    """Raised when all retry attempts for an HTTP status code have been exhausted."""
+
+    pass
+
+
 RetryPolicy = dict[int, int]  # {status_code: max_tries}
 
 
@@ -73,10 +79,10 @@ def retry_with_policy(policy: RetryPolicy) -> Callable:
     return decorator
 
 
-FALLBACK_RETRY_POLICY: RetryPolicy = {429: 5, 503: 3}
+FALLBACK_RETRY_POLICY: RetryPolicy = {429: 5, 503: 5}
 
 URL_RETRY_POLICIES: dict[str, RetryPolicy] = {
-    "sec.gov": {429: 100, 503: 100},
+    "sec.gov": {429: 20, 503: 20},
 }
 
 

--- a/finance_agent/get_agent.py
+++ b/finance_agent/get_agent.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from model_library.agent import Agent, AgentConfig, AgentHooks, TimeLimit, TurnLimit, TurnResult, default_before_query, truncate_oldest
+from model_library.agent import Agent, AgentConfig, AgentHooks, TimeLimit, ToolCallRecord, TurnLimit, TurnResult, default_before_query, truncate_oldest
 from model_library.base import LLM, LLMConfig, RawResponse, TextInput
 from model_library.base.input import InputItem, SystemInput
 from model_library.exceptions import MaxContextWindowExceededError
@@ -8,6 +8,7 @@ from model_library.registry_utils import get_registry_model
 from pydantic import BaseModel
 
 from .prompt import QUESTION_PROMPT, SYSTEM_PROMPT
+from .exceptions import RetryExhaustedError
 from .tools import (
     VALID_TOOLS,
     Calculator,
@@ -97,6 +98,10 @@ def get_agent(
             history.append(TextInput(text="Continue."))
         return default_before_query(history, last_error)
 
+    def _on_tool_result(record: ToolCallRecord, state: dict) -> None:
+        if record.error and record.error.type == "RetryExhaustedError":
+            raise RetryExhaustedError(record.error.message)
+
     def _should_stop(turn_result: TurnResult) -> bool:
         """Never stop on text-only responses.
 
@@ -117,5 +122,6 @@ def get_agent(
         hooks=AgentHooks(
             before_query=_before_query,
             should_stop=_should_stop,
+            on_tool_result=_on_tool_result,
         ),
     )

--- a/finance_agent/prompt.py
+++ b/finance_agent/prompt.py
@@ -14,7 +14,7 @@ You should include any necessary step-by-step reasoning, justification, calculat
 When possible, please provide any calculated answers to at least two decimal places (e.g. 18.78% rather than 19%). Please do not round intermediate steps in any calculations - you should only round your final answer.
 
 SEC filings are the most authoritative source of financial data. If a number appears in both an SEC filing and another source (e.g., a press release or company website), use the SEC filing's figure.
-You may freely use and cite non-SEC sources for information not available in SEC filings, such as Yahoo Finance for historical price data.
+You may freely use and cite non-SEC sources for information not available in SEC filings. For historical price data not available in SEC filings, use Yahoo Finance as the primary source.
 If the question references a specific source, make sure to incorporate information from that source, but still cross-reference SEC filings where relevant.
 
 When reporting financial figures, use the same scale and units as presented in the SEC filing (e.g., if the filing reports values "in millions," report your answer in millions), unless otherwise specified in the question.

--- a/finance_agent/tools.py
+++ b/finance_agent/tools.py
@@ -13,7 +13,7 @@ from tavily import AsyncTavilyClient
 
 from simpleeval import SimpleEval
 
-from .exceptions import get_retry_policy, retry_http_errors, retry_with_policy
+from .exceptions import RetryExhaustedError, get_retry_policy, retry_http_errors, retry_with_policy
 from .key_rotator import KeyRotator, get_rotator
 
 
@@ -133,7 +133,7 @@ class TavilyWebSearch(Tool):
             raise ValueError("TAVILY_API_KEY is not set")
         self.client = AsyncTavilyClient(api_key=tavily_api_key)
 
-    @retry_http_errors(429)
+    @retry_http_errors(429, 503, max_tries=8)
     async def _execute_search(
         self,
         search_query: str,
@@ -244,7 +244,7 @@ class EDGARSearch(Tool):
             self._key_rotator = get_rotator("SEC_EDGAR_API_KEY")
         self.sec_api_url: str = "https://api.sec-api.io/full-text-search"
 
-    @retry_http_errors(429, 503)
+    @retry_with_policy({429: 20, 503: 20})
     async def _execute_search(
         self,
         search_query: str,
@@ -314,6 +314,12 @@ class EDGARSearch(Tool):
         try:
             results = await self._execute_search(**args)
             return ToolOutput(output=json.dumps(results, default=str))
+        except aiohttp.ClientResponseError as e:
+            if e.status in (429, 503):
+                raise RetryExhaustedError(f"SEC API retry attempts exhausted for HTTP {e.status}") from e
+            error_msg = str(e)
+            logger.warning(f"EDGAR search failed: {error_msg}")
+            return ToolOutput(output=error_msg, error=error_msg)
         except Exception as e:
             error_msg = str(e)
             logger.warning(f"EDGAR search failed: {error_msg}")
@@ -356,7 +362,12 @@ class ParseHtmlPage(Tool):
                         )
                     raise
 
-        html_content = await _fetch(url)
+        try:
+            html_content = await _fetch(url)
+        except aiohttp.ClientResponseError as e:
+            if e.status in (429, 503) and "sec.gov" in url:
+                raise RetryExhaustedError(f"sec.gov retry attempts exhausted for HTTP {e.status}") from e
+            raise
 
         soup = BeautifulSoup(html_content, "html.parser")
         for script_or_style in soup(["script", "style"]):
@@ -400,6 +411,8 @@ class ParseHtmlPage(Tool):
             text_output = await self._parse_html_page(url)
             tool_result = await self._save_tool_output(text_output, key, state)
             return ToolOutput(output=tool_result)
+        except RetryExhaustedError:
+            raise
         except Exception as e:
             error_msg = str(e)
             logger.warning(f"Parse HTML page failed: {error_msg}")


### PR DESCRIPTION
- edgar_search + parse_html_page on sec.gov: raise RetryExhaustedError on SEC 429/503 retry exhausted so we
 can mark the task as an error instead of wasting time to reach the agent time limit.
 - Web search + non-SEC URLs: soft-fail on exhaustion so the agent can try alternative sources
 - Lower retry budgets: SEC capped at 20 attempts (~30 min), non-SEC fallback at 5, Tavily at 8. 
 - Update prompt to include Yahoo Finance as pricing data source
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/finance-agent-v2/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
