### PR TITLE
Recover from nonexistent SEC filing URLs

### DIFF
--- a/finance_agent/exceptions.py
+++ b/finance_agent/exceptions.py
@@ -16,6 +16,12 @@ class RetryExhaustedError(Exception):
     pass
 
 
+class SecFilingNotFoundError(Exception):
+    """Raised when EDGAR confirms that a filing accession does not exist."""
+
+    pass
+
+
 RetryPolicy = dict[int, int]  # {status_code: max_tries}
 
 

--- a/finance_agent/tools.py
+++ b/finance_agent/tools.py
@@ -5,6 +5,7 @@ import math
 import os
 import re
 from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 from bs4 import BeautifulSoup
@@ -16,6 +17,7 @@ from simpleeval import SimpleEval
 
 from .exceptions import (
     RetryExhaustedError,
+    SecFilingNotFoundError,
     get_retry_policy,
     retry_http_errors,
     retry_with_policy,
@@ -34,6 +36,39 @@ VALID_TOOLS = [
 ]
 
 _DATE_REGEX = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SEC_ARCHIVE_FILE_REGEX = re.compile(r"^(/Archives/edgar/data/\d+/\d{18}/)[^/]+$")
+
+
+def _canonical_sec_index_url(url: str) -> str | None:
+    parsed = urlsplit(url)
+    if parsed.scheme != "https" or parsed.netloc.lower() not in {
+        "sec.gov",
+        "www.sec.gov",
+    }:
+        return None
+
+    match = _SEC_ARCHIVE_FILE_REGEX.fullmatch(parsed.path)
+    if match is None:
+        return None
+    return f"https://{parsed.netloc.lower()}{match.group(1)}index.json"
+
+
+async def _missing_sec_index_url(url: str) -> str | None:
+    try:
+        canonical_url = _canonical_sec_index_url(url)
+        if canonical_url is None:
+            return None
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                canonical_url,
+                timeout=aiohttp.ClientTimeout(total=60),
+                headers={"User-Agent": "ValsAI/antoine@vals.ai"},
+                allow_redirects=False,
+            ) as response:
+                return canonical_url if response.status == 404 else None
+    except Exception:
+        return None
 
 
 def _validate_date_format(field_name: str, value: str) -> None:
@@ -393,6 +428,10 @@ class ParseHtmlPage(Tool):
         try:
             html_content = await _fetch(url)
         except aiohttp.ClientResponseError as e:
+            if e.status == 503 and (canonical_url := await _missing_sec_index_url(url)):
+                raise SecFilingNotFoundError(
+                    f"SEC filing not found: {canonical_url}"
+                ) from e
             if e.status in (429, 503) and "sec.gov" in url:
                 raise RetryExhaustedError(
                     f"sec.gov retry attempts exhausted for HTTP {e.status}"

--- a/tests/test_parse_html_page.py
+++ b/tests/test_parse_html_page.py
@@ -1,0 +1,146 @@
+import logging
+import unittest
+from contextlib import contextmanager
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
+
+import aiohttp
+
+from finance_agent.exceptions import RetryExhaustedError
+from finance_agent.tools import ParseHtmlPage
+
+
+FILING_URL = (
+    "https://www.sec.gov/Archives/edgar/data/874238/000087423826000005/"
+    "0000874238-26-000005-index.htm?output=1#top"
+)
+CANONICAL_INDEX_URL = (
+    "https://www.sec.gov/Archives/edgar/data/874238/000087423826000005/index.json"
+)
+
+
+def _response(url: str, status: int) -> MagicMock:
+    response = MagicMock(status=status)
+    if status >= 400:
+        response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(real_url=url),
+            history=(),
+            status=status,
+        )
+    return response
+
+
+def _response_context(response: MagicMock) -> MagicMock:
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=response)
+    context.__aexit__ = AsyncMock(return_value=None)
+    return context
+
+
+@contextmanager
+def _mock_requests(*responses: MagicMock | Exception):
+    session = MagicMock()
+    session.get.side_effect = [
+        response if isinstance(response, Exception) else _response_context(response)
+        for response in responses
+    ]
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=None)
+    with patch("finance_agent.tools.aiohttp.ClientSession", return_value=context):
+        yield session
+
+
+class ParseHtmlPageTest(unittest.IsolatedAsyncioTestCase):
+    async def test_downgrades_verified_missing_sec_filing_to_tool_error(self) -> None:
+        with (
+            patch("finance_agent.tools.get_retry_policy", return_value={503: 1}),
+            _mock_requests(
+                _response(FILING_URL, 503),
+                _response(CANONICAL_INDEX_URL, 404),
+            ) as session,
+        ):
+            result = await ParseHtmlPage().execute(
+                {"url": FILING_URL, "key": "filing"}, {}, logging.getLogger()
+            )
+
+        self.assertEqual(result.output, f"SEC filing not found: {CANONICAL_INDEX_URL}")
+        self.assertEqual(result.error, result.output)
+        self.assertEqual(
+            session.get.call_args_list,
+            [
+                call(FILING_URL, timeout=ANY, headers=ANY),
+                call(
+                    CANONICAL_INDEX_URL,
+                    timeout=ANY,
+                    headers=ANY,
+                    allow_redirects=False,
+                ),
+            ],
+        )
+
+    async def test_preserves_503_when_canonical_index_is_not_404(self) -> None:
+        for status in (200, 302, 403, 429, 500, 503):
+            with (
+                self.subTest(status=status),
+                patch("finance_agent.tools.get_retry_policy", return_value={503: 1}),
+                _mock_requests(
+                    _response(FILING_URL, 503),
+                    _response(CANONICAL_INDEX_URL, status),
+                ),
+                self.assertRaises(RetryExhaustedError),
+            ):
+                await ParseHtmlPage().execute(
+                    {"url": FILING_URL, "key": "filing"},
+                    {},
+                    logging.getLogger(),
+                )
+
+    async def test_preserves_503_when_canonical_index_cannot_be_verified(self) -> None:
+        with (
+            patch("finance_agent.tools.get_retry_policy", return_value={503: 1}),
+            _mock_requests(
+                _response(FILING_URL, 503),
+                aiohttp.ClientConnectionError("connection failed"),
+            ),
+            self.assertRaises(RetryExhaustedError),
+        ):
+            await ParseHtmlPage().execute(
+                {"url": FILING_URL, "key": "filing"}, {}, logging.getLogger()
+            )
+
+    async def test_preserves_429_without_probing_canonical_index(self) -> None:
+        with (
+            patch("finance_agent.tools.get_retry_policy", return_value={429: 1}),
+            _mock_requests(_response(FILING_URL, 429)) as session,
+            self.assertRaises(RetryExhaustedError),
+        ):
+            await ParseHtmlPage().execute(
+                {"url": FILING_URL, "key": "filing"}, {}, logging.getLogger()
+            )
+
+        self.assertEqual(session.get.call_count, 1)
+
+    async def test_preserves_503_for_unmatched_sec_url(self) -> None:
+        urls = (
+            "https://www.sec.gov/files/unavailable.html",
+            "http://www.sec.gov/Archives/edgar/data/874238/000087423826000005/file.htm",
+            "https://www.sec.gov.example/Archives/edgar/data/874238/000087423826000005/file.htm",
+            "https://www.sec.gov/Archives/edgar/data/874238/00008742382600005/file.htm",
+            "https://[www.sec.gov/Archives/edgar/data/874238/000087423826000005/file.htm",
+        )
+        for url in urls:
+            with (
+                self.subTest(url=url),
+                patch("finance_agent.tools.get_retry_policy", return_value={503: 1}),
+                _mock_requests(_response(url, 503)) as session,
+                self.assertRaises(RetryExhaustedError),
+            ):
+                await ParseHtmlPage().execute(
+                    {"url": url, "key": "filing"}, {}, logging.getLogger()
+                )
+
+            self.assertEqual(session.get.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Four independent Luna FAB tasks failed after the model composed nonexistent SEC accession URLs. The requested filing pages exhausted the existing SEC 503 retry policy, while each accession directory's canonical index.json returned 404. Retrying unchanged code is therefore deterministic, not an infrastructure canary.

## Change

- Match only HTTPS sec.gov or www.sec.gov EDGAR archive files with an 18-digit accession directory.
- After the original SEC 503 retries are exhausted, issue one bounded, non-redirecting request to that accession's canonical index.json.
- Convert only a direct canonical 404 into a recoverable SecFilingNotFoundError tool result so the agent can choose another filing or source.
- Preserve RetryExhaustedError for SEC 429, every non-404 canonical response, probe or parser failures, and unmatched URLs.

## Verification

- TMPDIR=/home/ec2-user/.scratch/tmp-luna uv run python -m unittest discover -s tests -v — 7 passed
- TMPDIR=/home/ec2-user/.scratch/tmp-luna uv run ruff check . — passed
- Python 3.12 basedpyright with the worktree venv — 0 errors, 0 warnings
- git diff --check — passed

## Release gate

Ready for external review; no merge, runner snapshot, service deploy, or production retry has been performed. After approval and a normal merge, the finance-agent gitlink must be bumped in fabv2-runner, a new immutable Daytona snapshot must be built, and fabv2-internal must be deployed with that exact snapshot before one failed-row canary.