### PR TITLE
Support custom endpoint and models

### DIFF
--- a/finance_agent/get_agent.py
+++ b/finance_agent/get_agent.py
@@ -1,11 +1,12 @@
+import os
 from pathlib import Path
 
 from model_library.agent import Agent, AgentConfig, AgentHooks, TimeLimit, ToolCallRecord, TurnLimit, TurnResult, default_before_query, truncate_oldest
 from model_library.base import LLM, LLMConfig, RawResponse, TextInput
 from model_library.base.input import InputItem, SystemInput
 from model_library.exceptions import MaxContextWindowExceededError
-from model_library.registry_utils import get_registry_model
-from pydantic import BaseModel
+from model_library.registry_utils import get_raw_model, get_registry_model
+from pydantic import BaseModel, SecretStr
 
 from .prompt import QUESTION_PROMPT, SYSTEM_PROMPT
 from .exceptions import RetryExhaustedError
@@ -38,8 +39,35 @@ def build_input(question: str) -> list[InputItem]:
 
 
 def create_llm(parameters: Parameters) -> LLM:
-    """Create an LLM instance from parameters using the model registry."""
-    return get_registry_model(parameters.model_name, parameters.llm_config)
+    """Create an LLM instance from parameters using the model registry.
+
+    With CUSTOM_ENDPOINT set, bypass the registry and target the given
+    OpenAI-compatible endpoint instead, so a model id the registry does not know
+    can still be run.
+    """
+    endpoint = os.environ.get("CUSTOM_ENDPOINT")
+    if not endpoint:
+        return get_registry_model(parameters.model_name, parameters.llm_config)
+
+    api_key = os.environ.get("CUSTOM_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "CUSTOM_ENDPOINT is set but CUSTOM_API_KEY is not; the custom endpoint "
+            "needs its own key. Without it the provider's default key (e.g. "
+            "OPENAI_API_KEY) would be sent to the custom endpoint."
+        )
+
+    config = parameters.llm_config.model_copy(
+        update={
+            "custom_endpoint": endpoint,
+            "custom_api_key": SecretStr(api_key),
+            # The agent drives a tool loop, so tool support is required of the endpoint.
+            "supports_tools": True,
+            # The endpoint's capabilities are unknown, so never send temperature.
+            "supports_temperature": False,
+        }
+    )
+    return get_raw_model(parameters.model_name, config=config)
 
 
 def get_agent(


### PR DESCRIPTION
Read `CUSTOM_ENDPOINT` and `CUSTOM_API_KEY` when building the LLM.

When `CUSTOM_ENDPOINT` is set, the model registry is bypassed and the given
OpenAI-compatible endpoint is targeted instead, so a model id the registry does
not know can still be run. When it is unset, behavior is unchanged.

Setting `CUSTOM_ENDPOINT` without `CUSTOM_API_KEY` raises, since the provider's
default key would otherwise be sent to the custom endpoint.

Caller-supplied `LLMConfig` values such as `--max-tokens` are preserved on the
custom path. `temperature` is not sent, as the endpoint's capabilities are
unknown.

https://claude.ai/code/session_017W13jMajkrXWkmgsTj9v3p
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/finance-agent-v2/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->